### PR TITLE
[feat] CapiFed- Capi Cluster의 federation join 자동화.

### DIFF
--- a/_yaml_Install/6.hypercloud4-operator.yaml
+++ b/_yaml_Install/6.hypercloud4-operator.yaml
@@ -63,7 +63,11 @@ spec:
         - name: PROAUTH_EXIST    
           value: "1"   #If, OpenAuth set "0"
         - name: PROAUTH_HTTP_PORT
-          value: "8080"  
+          value: "8080"
+        - name: HOSTCLUSTERNAME # host cluster name (when you types "kubectl config get-contexts")
+          value: "hostcluster"
+        - name: FED_NS # name of namespace which contains federation-system pods
+          value: "kube-federation-system"
         ports:
         - containerPort: 28677
         resources:

--- a/_yaml_Install/hypercloud4-server-mount.yaml
+++ b/_yaml_Install/hypercloud4-server-mount.yaml
@@ -63,6 +63,10 @@ spec:
           value: Asia/Seoul
         - name: PROAUTH_EXIST    
           value: "1"   #If, OpenAuth set "0"  
+        - name: HOSTCLUSTERNAME # host cluster name (when you types "kubectl config get-contexts")
+          value: "hostcluster"
+        - name: FED_NS # name of namespace which contains federation-system pods
+          value: "kube-federation-system"
         ports:
         - containerPort: 28677
         resources:

--- a/src/main/java/k8s/example/client/Constants.java
+++ b/src/main/java/k8s/example/client/Constants.java
@@ -29,6 +29,8 @@ public class Constants {
 	public static final String CUSTOM_OBJECT_PLURAL_ROLEBINDINGCLAIM = "rolebindingclaims";
 	public static final String CUSTOM_OBJECT_PLURAL_CATALOGSERVICECLAIM = "catalogserviceclaims";
 
+	public static final String PLURAL_SECRET = "secrets";
+
 	public static final String SERVICE_INSTANCE_API_GROUP = "servicecatalog.k8s.io";
 	public static final String SERVICE_INSTANCE_API_VERSION = "v1beta1";
 	public static final String SERVICE_INSTANCE_PLURAL = "serviceinstances";
@@ -36,6 +38,16 @@ public class Constants {
 
 	public static final String RBAC_API_GROUP = "rbac.authorization.k8s.io";
 	public static final String CORE_API_GROUP = "''";
+
+	//federation
+	public static final String FED_OBJECT_GROUP = "core.kubefed.io";
+	public static final String FED_OBJECT_VERSION =  "v1beta1";
+	public static final String FED_OBJECT_FEDCLUSTER_PLURAL = "kubefedclusters";
+
+	//capi
+	public static final String CAPI_OBJECT_GROUP = "cluster.x-k8s.io";
+	public static final String CAPI_OBJECT_VERSION =  "v1alpha3";
+	public static final String CAPI_OBJECT_PLURAL_CAPICLUSTER = "clusters";
 
 	// HTTPS REQUEST URL
 	public static final String HTTPS_SCHEME_PREFIX = "https://";

--- a/src/main/java/k8s/example/client/k8s/CapiClusterController.java
+++ b/src/main/java/k8s/example/client/k8s/CapiClusterController.java
@@ -1,0 +1,156 @@
+package k8s.example.client.k8s;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.util.Watch;
+import k8s.example.client.Constants;
+import k8s.example.client.Main;
+import k8s.example.client.models.CapiCluster;
+
+public class CapiClusterController extends Thread {
+	private Watch<CapiCluster> ccController;
+	private CoreV1Api coreApi;
+	private CustomObjectsApi api = null;
+
+	private static Logger logger = Main.logger;
+	private static long cclatestResourceVersion = 0;
+
+	private static String KUBECONFIG = "-kubeconfig";
+
+	CapiClusterController(ApiClient client, CustomObjectsApi api, CoreV1Api coreApi, long ccresourceVersion)
+			throws Exception {
+		ccController = Watch.createWatch(client,
+				api.listClusterCustomObjectCall(Constants.CAPI_OBJECT_GROUP, Constants.CAPI_OBJECT_VERSION,
+						Constants.CAPI_OBJECT_PLURAL_CAPICLUSTER, null, null, null, null, null, null, null,
+						Boolean.TRUE, null),
+				new TypeToken<Watch.Response<CapiCluster>>() {
+				}.getType());
+		this.api = api;
+		this.coreApi = coreApi;
+		cclatestResourceVersion = ccresourceVersion;
+	}
+
+	public void run() {
+		try {
+			while (true) {
+				ccController.forEach(response -> {
+					try {
+						if (Thread.interrupted()) {
+							logger.info("[CapiCluster controller] Interrupted");
+							ccController.close();
+						}
+					} catch (Exception e) {
+						logger.info(e.getMessage());
+					}
+
+					// Logic here
+					String clusterName = "unknown";
+					try {
+						CapiCluster cc = response.object;
+						if (cc != null) {
+							cclatestResourceVersion = Long
+									.parseLong(response.object.getMetadata().getResourceVersion());
+							String eventType = response.type.toString(); // ADDED, MODIFIED, DELETED
+							logger.info("[CapiCluster controller] Event Type : " + eventType);
+							clusterName = cc.getMetadata().getName();
+
+							if (cc.getMetadata().getAnnotations() != null
+									&& cc.getStatus() != null
+									&& cc.getStatus().getControlPlaneInitialized() != null
+									&& cc.getMetadata().getAnnotations().containsKey("federation") //AFJ(Auto Fed Join)
+									&& cc.getStatus().getControlPlaneInitialized().equals("true")
+									&& cc.getMetadata().getAnnotations().get("federation").toLowerCase().equals("join")) {
+								if(annotateKubeConfigSecret(clusterName+KUBECONFIG, "join")) replaceCCAnnotate(clusterName, "success");
+								else replaceCCAnnotate(clusterName, "error");
+							}
+						}
+					} catch (Exception e) {
+						printException(e, "CapiCluster handle");
+					} catch (Throwable e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+				});
+			}
+		} catch (Exception e) {
+			printException(e, "CapiCluster Controller");
+		}
+	}
+
+	private boolean annotateKubeConfigSecret(String name, String annotate) {
+		boolean result = false;
+		try {
+			V1Secret temp = coreApi.readNamespacedSecret(name, "default", null, null, null);
+			
+			Map<String, String> temp2 = new HashMap();
+			if(temp.getMetadata().getAnnotations() != null) temp2 = temp.getMetadata().getAnnotations();
+			temp2.put("federation", "join");
+			temp.getMetadata().setAnnotations(temp2);
+			coreApi.replaceNamespacedSecret(name, "default", temp, null, null, null);
+			result = true;
+		} catch (ApiException e1) {
+			printException(e1, "CapiCluster annotaubteKubeConfigSecret1");
+		}
+				
+		return result;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private void replaceCCAnnotate(String name, String annotate) throws ApiException {
+		JsonArray patchStatusArray = new JsonArray();
+		JsonObject patchStatus = new JsonObject();
+		JsonObject statusObject = new JsonObject();
+
+		statusObject.addProperty("federation", annotate);
+
+		patchStatus.addProperty("op", "replace");
+		patchStatus.addProperty("path", "/metadata/annotations");
+		patchStatus.add("value", statusObject);
+
+		patchStatusArray.add(patchStatus);
+
+		try {
+			api.patchNamespacedCustomObject(Constants.CAPI_OBJECT_GROUP, Constants.CAPI_OBJECT_VERSION, "default",
+					Constants.CAPI_OBJECT_PLURAL_CAPICLUSTER, name, patchStatusArray);
+		} catch (ApiException e) {
+			throw e;
+		}
+	}
+
+	private static void printException(Exception e, String message) {
+		logger.info("[CapiCluster controller] " + message + " Error");
+		logger.info("[CapiCluster controller] Exception: " + e.getMessage());
+		StringWriter sw = new StringWriter();
+		e.printStackTrace(new PrintWriter(sw));
+		logger.info(sw.toString());
+	}
+
+	public static void printApiException(ApiException e, String message) {
+		if (e.getCode() == 404)
+			return;
+
+		logger.info("[CapiCluster controller] " + message + " Error");
+		logger.info("Status code: " + e.getCode());
+		logger.info("Reason: " + e.getResponseBody());
+		logger.info("Response headers: " + e.getResponseHeaders());
+		e.printStackTrace();
+	}
+
+	public static long getLatestResourceVersion() {
+		return cclatestResourceVersion;
+	}
+}

--- a/src/main/java/k8s/example/client/k8s/JoinFedController.java
+++ b/src/main/java/k8s/example/client/k8s/JoinFedController.java
@@ -1,0 +1,413 @@
+package k8s.example.client.k8s;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Base64.Encoder;
+
+import org.slf4j.Logger;
+
+import com.google.gson.reflect.TypeToken;
+
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
+import io.kubernetes.client.openapi.models.V1ClusterRole;
+import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PolicyRule;
+import io.kubernetes.client.openapi.models.V1RoleRef;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1ServiceAccount;
+import io.kubernetes.client.openapi.models.V1Subject;
+import io.kubernetes.client.util.Config;
+import io.kubernetes.client.util.KubeConfig;
+import io.kubernetes.client.util.Watch;
+import k8s.example.client.Constants;
+import k8s.example.client.Main;
+import k8s.example.client.models.KubeFedCluster;
+import k8s.example.client.models.KubeFedCluster.KubeFedClusterSpec;
+import k8s.example.client.models.KubeFedCluster.SecretRef;
+
+public class JoinFedController extends Thread {
+	private Watch<V1Secret> jfController;
+	private CoreV1Api coreApi;
+	private CoreV1Api coreApiMember;
+	private CustomObjectsApi api = null;
+	private RbacAuthorizationV1Api rbaMemberMember;
+
+	private static long latestResourceVersion = 0;
+	
+	private static ApiClient MemberClient;
+	private static Logger logger = Main.logger;
+
+	private static String KUBECONFIG = "-kubeconfig";
+	private static String FED_HOSTCLUSTER = "-hostcluster";
+	private static String FED_NS = "kube-federation-system";
+	private static String ENV_FED_NS = "FED_NS";
+	private static String ENV_FED_HOSTCLUSTER = "HOSTCLUSTERNAME";
+	private static String FED_CONTOLLER = "kubefed-controller-manager:";
+	private static String HYPERCLOUD_OPERATOR = "-hypercloud4-operator";
+
+	JoinFedController(ApiClient client, CustomObjectsApi api, CoreV1Api coreApi, long resourceVersion)
+			throws Exception {
+		jfController = Watch.createWatch(client, coreApi.listSecretForAllNamespacesCall(null, null, null, null, null, null,  Long.toString( resourceVersion ), null, Boolean.TRUE, null),
+				new TypeToken<Watch.Response<V1Secret>>() {
+				}.getType());
+		this.api = api;
+		this.coreApi = coreApi;
+		latestResourceVersion = resourceVersion;
+		setEnv();
+	}
+
+	public void run() {
+		try {
+			while (true) {
+				jfController.forEach(response -> {
+					try {
+						if (Thread.interrupted()) {
+							logger.info("[JoinFed controller] Interrupted");
+							jfController.close();
+						}
+					} catch (Exception e) {
+						logger.info(e.getMessage());
+					}
+					
+					// Logic here
+					try {
+						V1Secret secret = response.object;
+						if (secret != null && secret.getMetadata().getName().contains(KUBECONFIG)) {
+							logger.info("[JoinFed controller] Event Type : " + response.type.toString()); // ADDED, MODIFIED, DELETED
+							
+							if (secret.getMetadata().getAnnotations() != null && secret.getMetadata().getAnnotations().containsKey("federation")) {
+								if (secret.getMetadata().getAnnotations().get("federation").toLowerCase().equals("join")) {
+									deleteFed(secret);
+									if (joinFed(secret))
+										replaceCCAnnotate(secret.getMetadata().getName(), "joined");
+									else {
+										deleteFed(secret);
+										replaceCCAnnotate(secret.getMetadata().getName(), "Error");
+									}
+								} else if (secret.getMetadata().getAnnotations().get("federation").toLowerCase()
+										.equals("detach")) {
+									deleteFed(secret);
+									replaceCCAnnotate(secret.getMetadata().getName(), "detached");
+								}
+							}
+						}
+					} catch (Exception e) {
+						printException(e, "JoinFed handle");
+					} catch (Throwable e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+				});
+			}
+		} catch (Exception e) {
+			printException(e, "JoinFed controller");
+		}
+	}
+
+	private void setEnv() {
+		if(System.getenv(ENV_FED_HOSTCLUSTER) != null) FED_HOSTCLUSTER = "-"+System.getenv(ENV_FED_HOSTCLUSTER);
+		if(System.getenv(ENV_FED_NS) !=null) FED_NS = System.getenv(ENV_FED_NS);
+	}
+	
+	private boolean joinFed(V1Secret kubeconfigSecret) {
+		boolean result = false;
+		Map<String, String> auth = null;
+		String apiURL = null;
+		String clusterName = kubeconfigSecret.getMetadata().getName().substring(0, kubeconfigSecret.getMetadata().getName().length() - KUBECONFIG.length());
+		
+		apiURL = setKubeConfig(kubeconfigSecret); // set kubeconfig to control join cluster.
+		if (apiURL != null) auth = initMember(clusterName); // create necessary resources for fed-join to join cluster
+		if (auth.size() == 2) result = initHost(clusterName, apiURL, auth); // set & create necessary resources in host cluster
+		return result;
+	}
+
+	private String setKubeConfig(V1Secret kubeconfigSecret) {
+		String apiURL = null;
+		try {
+			KubeConfig kubeconfig = KubeConfig
+					.loadKubeConfig(new StringReader(new String(kubeconfigSecret.getData().get("value"))));
+			apiURL = kubeconfig.getServer();
+			MemberClient = Config.fromConfig(kubeconfig);
+		} catch (IOException e) {
+			logger.info("[JoinFed controller] setMemberConfig-setMemberClient Error");
+			apiURL = null;
+		}
+		MemberClient.setConnectTimeout(0);
+		MemberClient.setReadTimeout(0);
+		MemberClient.setWriteTimeout(0);
+
+		coreApiMember = new CoreV1Api(MemberClient);
+		rbaMemberMember = new RbacAuthorizationV1Api(MemberClient);
+
+		return apiURL;
+	}
+
+	private Map<String, String> initMember(String clusterName) {
+		String saSecretName = null;
+		Map<String, String> auth = new HashMap<String, String>();
+
+		// create ns
+		V1Namespace ns = new V1Namespace();
+		V1ObjectMeta nsMeta = new V1ObjectMeta();
+		nsMeta.setName(FED_NS);
+		ns.setMetadata(nsMeta);
+		try {
+			ns = coreApiMember.createNamespace(ns, null, null, null);
+			logger.info("[JoinFed controller] created namespace in member cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-createNamespace");
+		}
+		
+		// create sa
+		V1ServiceAccount sa = new V1ServiceAccount();
+		V1ObjectMeta saMeta = new V1ObjectMeta();
+		saMeta.setName(clusterName + FED_HOSTCLUSTER);
+		saMeta.setNamespace(FED_NS);
+		sa.setMetadata(saMeta);
+		try {
+			coreApiMember.createNamespacedServiceAccount(FED_NS, sa, null, null, null);
+			logger.info("[JoinFed controller] created service account in member cluster ");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-createServiceAccount");
+		}
+		
+		// create cluster role
+		V1ClusterRole cr = new V1ClusterRole();
+		V1ObjectMeta crMeta = new V1ObjectMeta();
+		crMeta.setName(FED_CONTOLLER + clusterName + FED_HOSTCLUSTER);
+		cr.setMetadata(crMeta);
+		List<V1PolicyRule> rules = new ArrayList<>();
+
+		V1PolicyRule rule = new V1PolicyRule();
+		rule.addApiGroupsItem("*");
+		rule.addResourcesItem("*");
+		rule.addVerbsItem("*");
+		rules.add(rule);
+
+		rule = new V1PolicyRule();
+		rule.addNonResourceURLsItem("*");
+		rule.addVerbsItem("*");
+		rules.add(rule);
+
+		cr.setRules(rules);
+
+		try {
+			rbaMemberMember.createClusterRole(cr, null, null, null);
+			logger.info("[JoinFed controller] created clusterrole in member cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-createClusterRole");
+		}
+
+		// create cluster role binding
+		V1ClusterRoleBinding crb = new V1ClusterRoleBinding();
+		V1ObjectMeta crbMeta = new V1ObjectMeta();
+		crbMeta.setName(FED_CONTOLLER + clusterName + FED_HOSTCLUSTER);
+		crb.setMetadata(crbMeta);
+		V1RoleRef rr = new V1RoleRef();
+		rr.setApiGroup("rbac.authorization.k8s.io");
+		rr.setKind("ClusterRole");
+		rr.setName(FED_CONTOLLER + clusterName + FED_HOSTCLUSTER);
+		crb.setRoleRef(rr);
+		List<V1Subject> sl = new ArrayList<>();
+		V1Subject s = new V1Subject();
+		s.setKind("ServiceAccount");
+		s.setName(clusterName + FED_HOSTCLUSTER);
+		s.setNamespace(FED_NS);
+		sl.add(s);
+		crb.setSubjects(sl);
+
+		try {
+			rbaMemberMember.createClusterRoleBinding(crb, null, null, null);
+			logger.info("[JoinFed controller] created clusterrolebinding in member cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-createClusterRoleBinding");
+		}
+
+		// get saSecret for caBundle & token
+		try {
+			sa = coreApiMember.readNamespacedServiceAccount(clusterName + FED_HOSTCLUSTER, FED_NS, null, null, null);
+			saSecretName = sa.getSecrets().get(0).getName();
+			logger.info("[JoinFed controller] get sa from join cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-getSa");
+		}
+
+		try {
+			V1Secret saSecret = coreApiMember.readNamespacedSecret(saSecretName, FED_NS, null, false, false);
+			String ca = new String(saSecret.getData().get("ca.crt"));
+			String token = new String(saSecret.getData().get("token"));
+			auth.put("ca", ca);
+			auth.put("token", token);
+			logger.info("[JoinFed controller] get secret from join cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initMember-getSaSecret");
+		}
+
+		return auth;
+	}
+
+	private boolean initHost(String clusterName, String apiURL, Map<String, String> auth) {
+		// create secret in host cluster
+		V1Secret secret = new V1Secret();
+		V1ObjectMeta secretMeta = new V1ObjectMeta();
+		secretMeta.setName(clusterName + HYPERCLOUD_OPERATOR);
+		secretMeta.setNamespace(FED_NS);
+		secret.setMetadata(secretMeta);
+
+		Map<String, byte[]> data = new HashMap<>();
+		data.put("token", auth.get("token").getBytes());
+		secret.setData(data);
+
+		try {
+			coreApi.createNamespacedSecret(FED_NS, secret, null, null, null);
+			logger.info("[JoinFed controller] secret created in host cluster");
+		} catch (ApiException e) {
+			printApiException(e, "initHost-createSecret");
+			return false;
+		}
+
+		// create kubefedcluster crd
+		KubeFedCluster kfc = new KubeFedCluster();
+		V1ObjectMeta kfcMeta = new V1ObjectMeta();
+		Encoder encoder = Base64.getEncoder();
+		kfc.setApiVersion("core.kubefed.io/v1beta1");
+		kfc.setKind("KubeFedCluster");
+		kfcMeta.setName(clusterName);
+		kfcMeta.setNamespace(FED_NS);
+		kfc.setMetadata(kfcMeta);
+		KubeFedClusterSpec kfcs = new KubeFedClusterSpec();
+		kfcs.setApiEndpoint(apiURL);
+		kfcs.setCaBundle(new String(encoder.encode(auth.get("ca").getBytes())));
+		SecretRef sr = new SecretRef();
+		sr.setName(clusterName + HYPERCLOUD_OPERATOR);
+		kfcs.setSecretRef(sr);
+		kfc.setSpec(kfcs);
+
+		try {
+			api.createNamespacedCustomObject(Constants.FED_OBJECT_GROUP, Constants.FED_OBJECT_VERSION, FED_NS,
+					Constants.FED_OBJECT_FEDCLUSTER_PLURAL, kfc, null);
+		} catch (ApiException e) {
+			printApiException(e, "initHost-createKubefedcluster");
+			return false;
+		}
+
+		return true;
+	}
+
+	private void deleteFed(V1Secret kubeconfigSecret) {
+		String clusterName = kubeconfigSecret.getMetadata().getName().substring(0, kubeconfigSecret.getMetadata().getName().length() - KUBECONFIG.length());
+		
+		setKubeConfig(kubeconfigSecret);
+		delHost(clusterName);
+		delMember(clusterName);
+	}
+
+	private void delMember(String clusterName) {		
+		// delete ns
+		try {
+			coreApiMember.readNamespace(FED_NS, null, null, null);
+			coreApiMember.deleteNamespace(FED_NS, null, null, 0, null, "Background", new V1DeleteOptions());
+			logger.info("[JoinFed controller] namespace deleted in member cluster");
+		} catch (IllegalStateException e) {
+		} catch (ApiException e) {
+			printApiException(e, "delMember-deleteNamespace");
+		} catch (Exception e) {
+			printException(e, "delMember-deleteNamespace");
+		}
+
+		// delete clusterrole
+		String crName = FED_CONTOLLER + clusterName + FED_HOSTCLUSTER;
+		try {
+			rbaMemberMember.readClusterRole(crName, null);
+			rbaMemberMember.deleteClusterRole(crName, null, null, null, null, null, null);
+			logger.info("[JoinFed controller] clusterRole deleted in member cluster");
+		} catch (ApiException e) {
+			printApiException(e, "delMember-deleteClusterRole");
+		}
+
+		// delete clusterrolebinding
+		String crbName = FED_CONTOLLER + clusterName + FED_HOSTCLUSTER;
+		try {
+			rbaMemberMember.readClusterRoleBinding(crbName, null);
+			rbaMemberMember.deleteClusterRoleBinding(crbName, null, null, null, null, null, null);
+			logger.info("[JoinFed controller] clusterRoleBinding deleted in member cluster");
+		} catch (ApiException e) {
+			printApiException(e, "delMember-deleteClusterRole");
+		}
+
+	}
+
+	private void delHost(String clusterName) {
+		// delete kubefedcluster crd
+		String kfcName = clusterName;
+		try {
+			api.getNamespacedCustomObject(Constants.FED_OBJECT_GROUP, Constants.FED_OBJECT_VERSION, FED_NS,
+					Constants.FED_OBJECT_FEDCLUSTER_PLURAL, kfcName);
+			api.deleteNamespacedCustomObject(Constants.FED_OBJECT_GROUP, Constants.FED_OBJECT_VERSION, FED_NS,
+					Constants.FED_OBJECT_FEDCLUSTER_PLURAL, kfcName, null, null, null, null);
+			logger.info("[JoinFed controller] kubefedcluster deleted in host cluster");
+		} catch (ApiException e) {
+			printApiException(e, "delHost-deleteKubefedcluster");
+		}
+
+		// delete secret
+		String secretName = clusterName + HYPERCLOUD_OPERATOR;
+		try {
+			coreApi.readNamespacedSecret(secretName, FED_NS, null, null, null);
+			coreApi.deleteNamespacedSecret(secretName, FED_NS, null, null, null, null, null, null);
+			logger.info("[JoinFed controller] secret deleted in host cluster");
+		} catch (ApiException e) {
+			printApiException(e, "delHost-deleteSecret");
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void replaceCCAnnotate(String name, String annotate) throws ApiException {
+		String jsonPatchStr =
+			      "[{\"op\":\"replace\",\"path\":\"/metadata/annotations/federation\",\"value\":\""+annotate+"\"}]";
+				
+		try {
+			coreApi.patchNamespacedSecret(name, "default", new V1Patch(jsonPatchStr), null, null, null, null);
+		} catch (ApiException e) {
+			throw e;
+		}
+	}
+
+	private static void printException(Exception e, String message) {
+		logger.info("[JoinFed controller] " + message + " Error");
+		logger.info("[JoinFed controller] Exception: " + e.getMessage());
+		StringWriter sw = new StringWriter();
+		e.printStackTrace(new PrintWriter(sw));
+		logger.info(sw.toString());
+	}
+
+	public static void printApiException(ApiException e, String message) {
+		if (e.getCode() == 404)
+			return;
+
+		logger.info("[JoinFed controller] " + message + " Error");
+		logger.info("Status code: " + e.getCode());
+		logger.info("Reason: " + e.getResponseBody());
+		logger.info("Response headers: " + e.getResponseHeaders());
+		e.printStackTrace();
+	}
+
+	public static long getLatestResourceVersion() {
+		return latestResourceVersion;
+	}
+}

--- a/src/main/java/k8s/example/client/models/CapiCluster.java
+++ b/src/main/java/k8s/example/client/models/CapiCluster.java
@@ -1,0 +1,96 @@
+package k8s.example.client.models;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+
+public class CapiCluster {
+	private String resourceName = null;	
+	private String apiVersion = "cluster.x-k8s.io";
+	private String kind = null;
+	private V1ObjectMeta metadata = null;
+	private CapiClusterStatus status = null;
+	
+	public String getApiVersion() {
+		return apiVersion;
+	}
+	public void setApiVersion(String apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+	public String getKind() {
+		return kind;
+	}
+	public void setKind(String kind) {
+		this.kind = kind;
+	}
+	public String getResourceName() {
+		return resourceName;
+	}
+	public void setResourceName(String resourceName) {
+		this.resourceName = resourceName;
+	}
+	public V1ObjectMeta getMetadata() {
+		return metadata;
+	}
+	public void setMetadata(V1ObjectMeta metadata) {
+		this.metadata = metadata;
+	}
+	public CapiClusterStatus getStatus() {
+		return status;
+	}
+	public void setStatus(CapiClusterStatus status) {
+		this.status = status;
+	}
+		
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("class CapiMachine {\n");
+		sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
+		if(metadata != null ) 	sb.append("    metadata: ").append(toIndentedString(metadata.toString())).append("\n");
+		if(resourceName != null ) 	sb.append("    resourceName: ").append(toIndentedString(resourceName.toString())).append("\n");
+		if(status != null ) 	sb.append("    status: ").append(toIndentedString(status.toString())).append("\n");
+		sb.append("}");
+		return sb.toString();
+	}
+
+	/**
+	 * Convert the given object to string with each line indented by 4 spaces
+	 * (except the first line).
+	 */
+	public String toIndentedString(java.lang.Object o) {
+		if (o == null) {
+			return "null";
+		}
+		
+		return o.toString().replace("\n", "\n    ");
+	}
+	
+	public class CapiClusterStatus {
+		private String controlPlaneInitialized;
+
+		public String getControlPlaneInitialized() {
+			return controlPlaneInitialized;
+		}
+
+		public void setControlPlaneInitialized(String controlPlaneInitialized) {
+			this.controlPlaneInitialized = controlPlaneInitialized;
+		}
+		
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("class Capi Machine Status {\n");
+			if(controlPlaneInitialized != null ) 	sb.append("    phase: ").append(toIndentedString(controlPlaneInitialized)).append("\n");
+			sb.append("}");
+			return sb.toString();
+		}
+
+		/**
+		 * Convert the given object to string with each line indented by 4 spaces
+		 * (except the first line).
+		 */
+		private String toIndentedString(java.lang.Object o) {
+			if (o == null) {
+				return "null";
+			}
+			return o.toString().replace("\n", "\n    ");
+		}
+	}	
+}

--- a/src/main/java/k8s/example/client/models/KubeFedCluster.java
+++ b/src/main/java/k8s/example/client/models/KubeFedCluster.java
@@ -1,0 +1,135 @@
+package k8s.example.client.models;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+
+public class KubeFedCluster {
+	private V1ObjectMeta metadata = null;
+	private KubeFedClusterSpec spec = null;
+	private String apiVersion;
+	private String kind;	
+	
+	public String getApiVersion() {
+		return apiVersion;
+	}
+	public void setApiVersion(String apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+	public String getKind() {
+		return kind;
+	}
+	public void setKind(String kind) {
+		this.kind = kind;
+	}
+	public V1ObjectMeta getMetadata() {
+		return metadata;
+	}
+	public void setMetadata(V1ObjectMeta metadata) {
+		this.metadata = metadata;
+	}
+	public KubeFedClusterSpec getSpec() {
+		return spec;
+	}
+	public void setSpec(KubeFedClusterSpec spec) {
+		this.spec = spec;
+	}
+		
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("class KubeKubeFedCluster {\n");
+		sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
+		if(metadata != null ) 	sb.append("    metadata: ").append(toIndentedString(metadata.toString())).append("\n");
+		if(spec != null ) 	sb.append("    spec: ").append(toIndentedString(spec.toString())).append("\n");
+		sb.append("}");
+		return sb.toString();
+	}
+
+	public static class SecretRef {
+		private String name;
+		public String getName() {
+			return name;
+		}
+		public void setName(String name) {
+			this.name = name;
+		}
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("class SecretRef {\n");
+			if(name != null ) 	sb.append("    Name: ").append(toIndentedString(name)).append("\n");
+			sb.append("}");
+			return sb.toString();
+		}
+		
+		/**
+		 * Convert the given object to string with each line indented by 4 spaces
+		 * (except the first line).
+		 */	
+		private String toIndentedString(java.lang.Object o) {
+			if (o == null) {
+				return "null";
+			}
+			
+			return o.toString().replace("\n", "\n    ");
+		}
+	}
+	
+	public static class KubeFedClusterSpec {
+		private String apiEndpoint;
+		private String caBundle;
+		private SecretRef secretRef;
+
+		public String getApiEndpoint() {
+			return apiEndpoint;
+		}
+
+		public void setApiEndpoint(String APIEndpoint) {
+			this.apiEndpoint = APIEndpoint;
+		}
+		
+		public String getCaBundle() {
+			return caBundle;
+		}
+
+		public void setCaBundle(String CABundle) {
+			this.caBundle = CABundle;
+		}
+		
+		public SecretRef getSecretRef() {
+			return secretRef;
+		}
+
+		public void setSecretRef(SecretRef secretRef) {
+			this.secretRef = secretRef;
+		}
+		
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("class Capi Machine Spec {\n");
+			if(apiEndpoint != null ) 	sb.append("    APIEndpoint: ").append(toIndentedString(apiEndpoint)).append("\n");
+			if(caBundle != null ) 	sb.append("    CABundle: ").append(toIndentedString(caBundle)).append("\n");
+			if(secretRef != null ) 	sb.append("    secretRef: ").append(toIndentedString(secretRef)).append("\n");
+			sb.append("}");
+			return sb.toString();
+		}
+		
+		/**
+		 * Convert the given object to string with each line indented by 4 spaces
+		 * (except the first line).
+		 */	
+		private String toIndentedString(java.lang.Object o) {
+			if (o == null) {
+				return "null";
+			}
+			return o.toString().replace("\n", "\n    ");
+		}
+	}	
+	/**
+	 * Convert the given object to string with each line indented by 4 spaces
+	 * (except the first line).
+	 */	
+	private String toIndentedString(java.lang.Object o) {
+		if (o == null) {
+			return "null";
+		}
+		return o.toString().replace("\n", "\n    ");
+	}
+}


### PR DESCRIPTION
목적
 - Capi프로젝트로 구축된 cluster는 단순 cluster provisioning 기능만 수행하며, 해당 cluster에
k8s resource(ex pod)을 제어 및 배포 할 수 없다. 해당 cluster를 제어 및 배포 하기 위해,
federation프로젝트를 사용해야 한다.
 - 서로다른 두 프로젝트의 매끄러운 사용을 위해 CapiCluster/JoinFed Controller를 사용한다.

사용 방법
 - 6.hypercloud4-server-mount.yaml의 환경변수인 HOST_CLUSTER_NAME와 FED_NS를 적절히
기입하여 hypercloud4-operator를 수행한다.
 - capi의 cluster 리소스에 federation:join annotation을 기입한다.